### PR TITLE
Handling unsaved events

### DIFF
--- a/eventsource.gradle
+++ b/eventsource.gradle
@@ -57,7 +57,7 @@ release {
     // need to specify the repository to interact with
     grgit = Grgit.open(project.file('.'))
 
-    defaultVersionStrategy = Strategies.SNAPSHOT
+    defaultVersionStrategy = Strategies.FINAL
 
     // the approach to creating tags can also be modified
     tagStrategy {

--- a/eventsource.gradle
+++ b/eventsource.gradle
@@ -44,6 +44,7 @@ dependencies {
     compile "org.slf4j:slf4j-api:1.7.10"
 
     testCompile "org.spockframework:spock-core:0.7-groovy-2.0"
+    testCompile "cglib:cglib-nodep:3.2.2"
     testCompile "ch.qos.logback:logback-core:1.1.3"
     testCompile "ch.qos.logback:logback-classic:1.1.3"
 

--- a/src/main/groovy/com/thirdchannel/eventsource/EventSourceService.groovy
+++ b/src/main/groovy/com/thirdchannel/eventsource/EventSourceService.groovy
@@ -102,7 +102,13 @@ class EventSourceService<A extends Aggregate> {
         .flatMap({it})
         .buffer(500)
         .map({ List<? extends Event> events ->
-            eventService.save(events)
+            boolean eventsSaved = eventService.save(events)
+
+            if(!eventsSaved) {
+                log.warn("Failed to save events")
+            }
+
+            eventsSaved
         } as Func1)
         .all({ boolean eventsSaved -> eventsSaved } as Func1)
         .subscribe({ boolean allSaved ->


### PR DESCRIPTION
Found an issue where if the event service returned false everything that followed would continue as if all events were really saved.

So `eventService.save` returned false, but because it wasn't an exception everything would continue as normal. The on complete function of the `subscribe` would still be called, and the save function would return true even though the events weren't saved properly.